### PR TITLE
remove lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "license": "ISC",
   "dependencies": {
     "babel-polyfill": "^6.23.0",
-    "lodash": "^4.17.4",
+    "lodash.merge": "^4.6.0",
+    "lodash.snakecase": "^4.1.1",
     "ramda": "^0.24.1",
     "redux-actions": "^2.0.3"
   },

--- a/src/hammock.js
+++ b/src/hammock.js
@@ -2,7 +2,7 @@
 /* global fetch */
 import { createAction } from 'redux-actions'
 import R from 'ramda'
-import _ from 'lodash'
+import snakeCase from 'lodash.snakecase'
 
 import type { Action, ActionType, Dispatcher } from './reduxTypes'
 import type { Endpoint } from './restTypes'
@@ -17,7 +17,7 @@ import {
 } from './constants'
 import { withUsername, updateStateByUsername } from './util'
 
-const actionize = R.compose(R.toUpper, R.join('_'), R.map(_.snakeCase))
+const actionize = R.compose(R.toUpper, R.join('_'), R.map(snakeCase))
 
 export const requestActionType = (...xs: string[]) => `REQUEST_${actionize(xs)}`
 
@@ -47,7 +47,12 @@ export function makeFetchFunc (endpoint: Endpoint, verb: string): (...args: any)
   let url = getUrl(endpoint, verb)
   let options = getMakeOptions(endpoint, verb)
   return (...args) => {
-    return fetch(_.isFunction(url) ? url(...args) : url, options(...args))
+    return fetch(
+      typeof url === 'function'
+      ? url(...args)
+      : url,
+      options(...args)
+    )
   }
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,7 +1,7 @@
 // @flow
 import R from 'ramda'
-import _ from 'lodash'
 import { createAction } from 'redux-actions'
+import merge from 'lodash.merge'
 
 import type { ActionType } from './reduxTypes'
 
@@ -18,5 +18,5 @@ export const withUsername = (type: ActionType, payloadFunc: Function = R.nthArg(
 )
 
 export const updateStateByUsername = (state: Object, username: string, update: Object) => (
-  _.merge({}, state, { [username]: update })
+  merge({}, state, { [username]: update })
 )

--- a/src/util_test.js
+++ b/src/util_test.js
@@ -1,7 +1,7 @@
 // @flow
 import { assert } from 'chai'
 
-import { withUsername } from './util'
+import { withUsername, updateStateByUsername } from './util'
 
 describe('utils', () => {
   describe('withUsername', () => {
@@ -18,6 +18,46 @@ describe('utils', () => {
         type: TYPE,
         payload: { my: 'payload' },
         meta: 'username'
+      })
+    })
+  })
+
+  describe('updateStateByUsername', () => {
+    it('should namespace the update under the username', () => {
+      let state = {}
+      assert.deepEqual(updateStateByUsername(state, 'foobar', { potato: 'bread' }), {
+        foobar: {
+          potato: 'bread'
+        }
+      })
+    })
+
+    it('should leave stuff already on the state intact', () => {
+      let state = { potato: 'bread' }
+      assert.deepEqual(updateStateByUsername(state, 'foobar', { rice: 'bread' }), {
+        foobar: {
+          rice: 'bread'
+        },
+        potato: 'bread'
+      })
+    })
+
+    it('should update over the old state for the username', () => {
+      let state = { foobar: { potato: 'pancake' } }
+      assert.deepEqual(updateStateByUsername(state, 'foobar', { potato: 'bread' }), {
+        foobar: {
+          potato: 'bread'
+        }
+      })
+    })
+
+    it('should deeply merge the update with the current state', () => {
+      let state = { foobar: { existing: 'state' } }
+      assert.deepEqual(updateStateByUsername(state, 'foobar', { potato: 'bread' }), {
+        foobar: {
+          existing: 'state',
+          potato: 'bread'
+        }
       })
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1427,7 +1427,15 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash.merge@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
this removes lodash 

fixes #3 

unfortunately though, it looks like lodash is a dependency of a lot of our dependencies, so it might still get pulled in when installing.