### PR TITLE
set up build stuff for publishing the package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: false
 cache: yarn
 node_js:
   - "6"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "redux-hammock",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A library for simplyfing the use of redux-thunk with REST APIs",
-  "main": "index.js",
+  "main": "dist/hammock.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/mitodl/redux-hammock"
@@ -12,7 +12,9 @@
     "watch": "mocha --watch --require babel-polyfill --compilers js:babel-register src/*_test.js",
     "lint": "standard --env mocha",
     "flow": "flow",
-    "fmt": "standard --env mocha --fix"
+    "fmt": "standard --env mocha --fix",
+    "build": "rollup -c",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "redux",
@@ -30,6 +32,7 @@
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-eslint": "^7.2.3",
+    "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-env": "^1.5.2",
     "babel-preset-flow": "^6.23.0",
@@ -39,6 +42,8 @@
     "flow-bin": "^0.47.0",
     "mocha": "^3.4.2",
     "redux-asserts": "^0.0.10",
+    "rollup": "^0.43.0",
+    "rollup-plugin-babel": "^2.7.1",
     "sinon": "^2.3.4",
     "standard": "^10.0.2"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,25 @@
+import babel from 'rollup-plugin-babel'
+
+const babelConfig = {
+  presets: [
+    'flow',
+    ['env', { modules: false }]
+  ],
+  plugins: [
+    'transform-object-rest-spread',
+    'external-helpers'
+  ],
+  babelrc: false,
+  exclude: 'node_modules/**'
+}
+
+export default [
+  {
+    entry: 'src/hammock.js',
+    format: 'cjs',
+    dest: 'dist/hammock.js',
+    plugins: [
+      babel(babelConfig)
+    ]
+  }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,7 +78,7 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.24.1, babel-core@^6.25.0:
+babel-core@6, babel-core@^6.24.1, babel-core@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
   dependencies:
@@ -237,6 +237,12 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-external-helpers@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz#2285f48b02bd5dede85175caf8c62e86adccefa1"
+  dependencies:
+    babel-runtime "^6.22.0"
+
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
@@ -287,7 +293,7 @@ babel-plugin-transform-es2015-block-scoping@^6.23.0:
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
-babel-plugin-transform-es2015-classes@^6.23.0:
+babel-plugin-transform-es2015-classes@^6.23.0, babel-plugin-transform-es2015-classes@^6.9.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz#5a4c58a50c9c9461e564b4b2a3bfabc97a2584db"
   dependencies:
@@ -1015,6 +1021,10 @@ estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
 estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
+
+estree-walker@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
 
 esutils@^2.0.2:
   version "2.0.2"
@@ -1797,6 +1807,28 @@ rimraf@^2.2.8:
   dependencies:
     glob "^7.0.5"
 
+rollup-plugin-babel@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-2.7.1.tgz#16528197b0f938a1536f44683c7a93d573182f57"
+  dependencies:
+    babel-core "6"
+    babel-plugin-transform-es2015-classes "^6.9.0"
+    object-assign "^4.1.0"
+    rollup-pluginutils "^1.5.0"
+
+rollup-pluginutils@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
+  dependencies:
+    estree-walker "^0.2.1"
+    minimatch "^3.0.2"
+
+rollup@^0.43.0:
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.43.0.tgz#b36bdb75fa5e0823b6de8aee18ff7b5655520543"
+  dependencies:
+    source-map-support "^0.4.0"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -1852,7 +1884,7 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
-source-map-support@^0.4.2:
+source-map-support@^0.4.0, source-map-support@^0.4.2:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.15.tgz#03202df65c06d2bd8c7ec2362a193056fef8d3b1"
   dependencies:


### PR DESCRIPTION
closes #9 

I think this is all set. I published twice under the `beta` tag.

To test this out do this:

```
mkdir /tmp/foobar
cd /tmp/foobar
npm init
npm install redux-hammock@beta
```

then confirm that if you `require('redux-hammock')` in the node repl you see some exported functions. An easy one to test is `requestActionType`, which should return a string when passed a string.

I think also test that the `build` script does something sensible - if you run it there should be a file written to `dist/hammock.js` which is transpiled to ES5.