### PR TITLE
add constants.js to what we export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "redux-hammock",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "A library for simplyfing the use of redux-thunk with REST APIs",
   "main": "hammock.js",
   "files": [
-    "django_csrf_fetch.js"
+    "django_csrf_fetch.js",
+    "constants.js"
   ],
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,5 +42,14 @@ export default [
       babel(babelConfig)
     ],
     external: externals
+  },
+  {
+    entry: 'src/constants.js',
+    format: 'cjs',
+    dest: 'constants.js',
+    plugins: [
+      babel(babelConfig)
+    ],
+    external: externals
   }
 ]


### PR DESCRIPTION
I left this off, oops. These changes are published under the `beta` tag. to test:

```
cd /tmp/testing
npm init
npm install redux-hammock@beta
```

and confirm that you can `require('redux-hammock/constants')` in the node REPL. It should export a few constant strings and the `INITIAL_STATE` object