### PR TITLE
add support for delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-hammock",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A library for simplyfing the use of redux-thunk with REST APIs",
   "main": "hammock.js",
   "files": [

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,7 @@ import type { RestState } from './restTypes'
 export const GET = 'GET'
 export const PATCH = 'PATCH'
 export const POST = 'POST'
+export const DELETE = 'DELETE'
 
 export const FETCH_PROCESSING = 'FETCH_PROCESSING'
 export const FETCH_SUCCESS = 'FETCH_SUCCESS'

--- a/src/hammock.js
+++ b/src/hammock.js
@@ -14,6 +14,7 @@ import {
   GET,
   PATCH,
   POST,
+  DELETE,
   INITIAL_STATE
 } from './constants'
 import { withUsername, updateStateByUsername } from './util'
@@ -28,7 +29,7 @@ export const failureActionType = (...xs: string[]) => `RECEIVE_${actionize(xs)}_
 
 export const clearActionType = (...xs: string[]) => `CLEAR_${actionize(xs)}`
 
-const defaultRESTPrefixes = { GET, PATCH, POST }
+const defaultRESTPrefixes = { GET, PATCH, POST, DELETE }
 
 const getPrefixForEndpoint = (verb, endpoint) => (
   R.propOr(defaultRESTPrefixes[verb], `${R.toLower(verb)}Prefix`, endpoint)

--- a/src/hammock_test.js
+++ b/src/hammock_test.js
@@ -11,6 +11,7 @@ import {
   GET,
   POST,
   PATCH,
+  DELETE,
   INITIAL_STATE
 } from './constants'
 import {
@@ -83,11 +84,13 @@ describe('redux REST', () => {
       endpoint = {
         getUrl: '/get',
         postUrl: '/post',
-        patchUrl: '/patch'
+        patchUrl: '/patch',
+        deleteUrl: '/delete'
       }
       fetchMock.mock('/get', {})
       fetchMock.mock('/post', {})
       fetchMock.mock('/patch', {})
+      fetchMock.mock('/delete', {})
       sandbox = sinon.sandbox.create()
     })
 
@@ -108,7 +111,7 @@ describe('redux REST', () => {
       assert(endpoint.fetchFunc.called)
     });
 
-    [GET, POST, PATCH].forEach(verb => {
+    [GET, POST, PATCH, DELETE].forEach(verb => {
       it(`should call the endpoint.${R.toLower(verb)}Url function, if provided`, () => {
         let key = `${R.toLower(verb)}Url`
         endpoint[key] = sandbox.stub().returns(`/${R.toLower(verb)}`)


### PR DESCRIPTION
closes #18 

this just adds support for the DELETE HTTP verb to hammock.

testing probably isn't necessary, unless the code looks weird.