### PR TITLE
Updated hammock to allow any verbs and added deriver for verbFuncs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 hammock.js
 django_csrf_fetch.js
+constants.js
 !src/*
+*.tgz

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "isomorphic-fetch": "^2.2.1",
     "lodash.merge": "^4.6.0",
     "lodash.snakecase": "^4.1.1",
+    "lodash.camelcase": "^4.1.1",
     "ramda": "^0.24.1",
     "redux-actions": "^2.0.3"
   },

--- a/src/util.js
+++ b/src/util.js
@@ -20,3 +20,6 @@ export const withUsername = (type: ActionType, payloadFunc: Function = R.nthArg(
 export const updateStateByUsername = (state: Object, username: string, update: Object) => (
   merge({}, state, { [username]: update })
 )
+
+// from: https://github.com/ramda/ramda/wiki/Cookbook#rename-keys-of-an-object-by-a-function
+export const renameBy = R.curry((fn, obj) => R.pipe(R.toPairs, R.map(R.adjust(fn, 0)), R.fromPairs)(obj))

--- a/src/util_test.js
+++ b/src/util_test.js
@@ -3,7 +3,8 @@ import { assert } from 'chai'
 
 import {
   withUsername,
-  updateStateByUsername
+  updateStateByUsername,
+  renameBy
 } from './util'
 
 describe('utils', () => {
@@ -60,6 +61,24 @@ describe('utils', () => {
         foobar: {
           existing: 'state',
           potato: 'bread'
+        }
+      })
+    })
+  })
+
+  describe('renameBy', () => {
+    it('should rename only top-level keys based on a function', () => {
+      const value = {
+        a: '1',
+        b: {
+          c: 2
+        }
+      }
+      const renameByAppending = renameBy((key) => `${key}Renamed`)
+      assert.deepEqual(renameByAppending(value), {
+        aRenamed: '1',
+        bRenamed: {
+          c: 2
         }
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1705,6 +1705,10 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
 
+lodash.camelcase@^4.1.1:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"


### PR DESCRIPTION
Fixes #16 

I generalized logic that limited action creators to http verbs and added a new utility that derives both `verbs` and `` `${verbName}Func` `` values


Tests should pass