### PR TITLE
Bump CI workflow to use 16.20.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up NodeJS
         uses: actions/setup-node@v2-beta
         with:
-          node-version: 15.3.0
+          node-version: 16.20.2
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
### What are the relevant tickets?

n/a

### Description (What does it do?)

CI was using node 15.3 and tests were failing (`Error: Cannot find module 'node:process'` - see https://github.com/mitodl/redux-hammock/actions/runs/11004936788/job/30556765906?pr=58 ), so bumped to 16 to fix that and unblock at least one Renovate PR.

### How can this be tested?

CI tests should pass.